### PR TITLE
add reference allele in abreak sv calling mode

### DIFF
--- a/faidx.c
+++ b/faidx.c
@@ -403,6 +403,18 @@ int faidx_fetch_nseq(const faidx_t *fai)
 	return fai->n;
 }
 
+const char *faidx_iseq(const faidx_t *fai, int i)
+{
+	return fai->name[i];
+}
+
+int faidx_seq_len(const faidx_t *fai, const char *seq)
+{
+	khint_t k = kh_get(s, fai->hash, seq);
+	if ( k == kh_end(fai->hash) ) return -1;
+	return kh_val(fai->hash, k).len;
+}
+
 char *faidx_fetch_seq(const faidx_t *fai, char *c_name, int p_beg_i, int p_end_i, int *len)
 {
 	int l;

--- a/faidx.h
+++ b/faidx.h
@@ -96,6 +96,16 @@ extern "C" {
 	 */
 	char *faidx_fetch_seq(const faidx_t *fai, char *c_name, int p_beg_i, int p_end_i, int *len);
 
+	/*!
+	  @abstract    Return name of i-th sequence
+	 */
+	const char *faidx_iseq(const faidx_t *fai, int i);
+
+	/*!
+	  @abstract    Return sequence length, -1 if not present
+	 */
+	int faidx_seq_len(const faidx_t *fai, const char *seq);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- add reference allele in abreak sv calling mode
- add reference and contig lines to vcf output
- INFO/END missing from header
- faidx.[ch] additions from upstream htslib

there is bit of jumping around with the faidx lookup, but there are not that many calls per-sample and it is optional...
